### PR TITLE
Fedora instructions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ sudo apt update
 sudo apt install -y tdlib-dev
 ```
 
+Fedora:
+```bash
+sudo dnf update
+sudo dnf install tdlib-static
+```
+
 #### Manual compilation
 
 ```bash


### PR DESCRIPTION
Works for Fedora 27/28/29/Rawhide. It also supports i386, not only x86_64