### PR TITLE
Receive updates based on certain filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ for update := range listener.Updates {
 }
 ```
 
+### Receive updates through event collector
+
+```go
+tdlibClient, err := client.NewClient(authorizer)
+if err != nil {
+    log.Fatalf("NewClient error: %s", err)
+}
+
+collector := client.NewEventCollector(tdlibClient)
+
+in := func(cl *client.Client, message client.Message) {
+    log.Println("A forwarded message which contains a video was received")
+}
+
+edit := func(cl *client.Client, message client.Message) {
+    log.Println("This message was edited by somone")
+}
+
+cmd := func(cl *client.Client, args []string) {
+    log.Println(args)
+}
+
+go collector.OnMessage(in, client.FilterVideo, client.FilterForwarded)
+go collector.OnEditedMessage(edit, client.FilterNotMe)
+go collector.OnCommand(cmd, "test", "/")
+
+collector.Wait()
+```
+
 ### Proxy support
 
 ```go

--- a/client/event.go
+++ b/client/event.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"sync"
+)
+
+var clientID int32 // store client.GetMe().id once Collector in created (to be used with FilterMe and FilterNotMe)
+
+// Collector provides the instance for collecting events (updates)
+type Collector struct {
+	client           *Client
+	wg               sync.WaitGroup
+	registerListener chan *Listener
+	listeners        []*Listener
+	sync.Mutex
+}
+
+//NewEventCollector - creates a new Collector instance with default configuration
+func NewEventCollector(c *Client) *Collector {
+	me, _ := c.GetMe()
+	clientID = me.Id
+	return &Collector{client: c, registerListener: make(chan *Listener, 1)}
+}
+
+func (collector *Collector) getMessage(update Type) Message {
+	switch update.GetType() {
+	case TypeUpdateNewMessage:
+		return *update.(*UpdateNewMessage).Message
+	default:
+		return Message{}
+	}
+}
+
+// OnMessage for incoming and outgoing messages that don't have a request cost
+func (collector *Collector) OnMessage(fn func(*Client, Message), filters ...string) {
+	listener := collector.client.GetListener()
+	collector.registerListener <- listener
+	for update := range listener.Updates {
+		if update.GetClass() == ClassUpdate {
+			message := collector.getMessage(update)
+			if (Message{}) != message && applyFilters(&message, filters) {
+				fn(collector.client, message)
+			}
+		}
+
+	}
+}
+
+func (collector *Collector) getEditedMessage(update Type) Message {
+	if update.GetType() == TypeUpdateMessageEdited {
+		info := *update.(*UpdateMessageEdited)
+		message, err := collector.client.GetMessage(
+			&GetMessageRequest{
+				ChatId:    info.ChatId,
+				MessageId: info.MessageId,
+			})
+		if err == nil {
+			return *message
+		}
+	}
+	return Message{}
+}
+
+// OnEditedMessage there's a request cost in receiving edited messages,
+// therefore it's a separate method (requires a get request that may fail for varius reasons)
+func (collector *Collector) OnEditedMessage(fn func(*Client, Message), filters ...string) {
+	filters = append(filters, "FilterEdited")
+	listener := collector.client.GetListener()
+	collector.registerListener <- listener
+	for update := range listener.Updates {
+		if update.GetClass() == ClassUpdate {
+			message := collector.getEditedMessage(update)
+			if (Message{}) != message && applyFilters(&message, filters) {
+				fn(collector.client, message)
+			}
+		}
+
+	}
+}
+
+// OnCommand commands are a specific type of filter on incoming messages that are sent by others
+func (collector *Collector) OnCommand(fn func(*Client, []string), cmd, prefix string) {
+	filters := []string{"FilterIncoming", "FilterNotMe", "FilterText"}
+	listener := collector.client.GetListener()
+	collector.registerListener <- listener
+	for update := range listener.Updates {
+		if update.GetClass() == ClassUpdate {
+			message := collector.getMessage(update)
+			if (Message{}) != message && applyFilters(&message, filters) {
+				if args := isValidCommand(&message, cmd, prefix); args != nil {
+					fn(collector.client, args)
+				}
+			}
+		}
+
+	}
+}
+
+// Wait - Wait on events
+func (collector *Collector) Wait() {
+	go func(ch chan *Listener) {
+		for value := range ch {
+			collector.Lock()
+			collector.listeners = append(collector.listeners, value)
+			collector.Unlock()
+		}
+	}(collector.registerListener)
+
+	collector.wg.Add(1)
+	collector.wg.Wait()
+}
+
+//Close - closes Collector instance
+func (collector *Collector) Close() {
+	collector.Lock()
+	listeners := collector.listeners
+	collector.Unlock()
+	for _, item := range listeners {
+		item.Close()
+	}
+	collector.wg.Done()
+}

--- a/client/filter.go
+++ b/client/filter.go
@@ -1,0 +1,281 @@
+package client
+
+import "strings"
+
+func applyFilters(message *Message, filters []string) bool {
+	c := 0
+	for _, f := range filters {
+		if filter[f](message) {
+			c++
+		}
+	}
+	if c == len(filters) {
+		return true
+	}
+	return false
+}
+
+func isValidCommand(message *Message, cmd, prefix string) []string {
+	rawText := strings.Trim(message.Content.(*MessageText).Text.Text, " ")
+	args := strings.Fields(rawText)
+	command := strings.Trim(prefix+cmd, " ")
+	if args[0] == command {
+		return args
+	}
+	return nil
+}
+
+func notMe(message *Message) bool {
+	if message.SenderUserId != clientID {
+		return true
+	}
+	return false
+}
+
+func me(message *Message) bool {
+	if message.SenderUserId == clientID {
+		return true
+	}
+	return false
+}
+
+func incoming(message *Message) bool {
+	if !message.IsOutgoing {
+		return true
+	}
+	return false
+}
+
+func outgoing(message *Message) bool {
+	if message.IsOutgoing {
+		return true
+	}
+	return false
+}
+
+func text(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageText {
+		return true
+	}
+	return false
+}
+
+func reply(message *Message) bool {
+	if message.ReplyToMessageId != 0 {
+		return true
+	}
+	return false
+}
+
+func forwarded(message *Message) bool {
+	if message.ForwardInfo != nil {
+		return true
+	}
+	return false
+}
+
+func caption(message *Message) bool {
+	var caption string
+	switch message.Content.MessageContentType() {
+	case TypeMessageAudio:
+		caption = message.Content.(*MessageAudio).Caption.Text
+	case TypeMessageVideo:
+		caption = message.Content.(*MessageVideo).Caption.Text
+	case TypeMessageAnimation:
+		caption = message.Content.(*MessageAnimation).Caption.Text
+	case TypeMessageDocument:
+		caption = message.Content.(*MessageDocument).Caption.Text
+	case TypeMessagePhoto:
+		caption = message.Content.(*MessagePhoto).Caption.Text
+	case TypeMessageVoiceNote:
+		caption = message.Content.(*MessageVoiceNote).Caption.Text
+	}
+
+	if caption != "" {
+		return true
+	}
+	return false
+
+}
+
+func edited(message *Message) bool {
+	if message.EditDate != 0 {
+		return true
+	}
+	return false
+}
+
+func audio(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageAudio {
+		return true
+	}
+	return false
+}
+
+func document(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageDocument {
+		return true
+	}
+	return false
+}
+
+func photo(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessagePhoto {
+		return true
+	}
+	return false
+}
+
+func sticker(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageSticker {
+		return true
+	}
+	return false
+
+}
+
+func animation(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageAnimation {
+		return true
+	}
+	return false
+}
+
+func game(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageGame {
+		return true
+	}
+	return false
+}
+
+func video(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageVideo {
+		return true
+	}
+	return false
+}
+
+func voice(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageVoiceNote {
+		return true
+	}
+	return false
+}
+
+func videoNote(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageVideoNote {
+		return true
+	}
+	return false
+}
+
+func contact(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageContact {
+		return true
+	}
+	return false
+}
+
+func location(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageLocation {
+		return true
+	}
+	return false
+}
+
+func venue(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessageVenue {
+		return true
+	}
+	return false
+}
+
+func poll(message *Message) bool {
+	if message.Content.MessageContentType() == TypeMessagePoll {
+		return true
+	}
+	return false
+}
+
+func channel(message *Message) bool {
+	return message.IsChannelPost
+}
+
+func media(message *Message) bool {
+	switch message.Content.MessageContentType() {
+	case TypeMessageAudio:
+		return true
+	case TypeMessageVideo:
+		return true
+	case TypeMessageAnimation:
+		return true
+	case TypeMessageDocument:
+		return true
+	case TypeMessagePhoto:
+		return true
+	case TypeMessageVoiceNote:
+		return true
+	default:
+		return false
+	}
+
+}
+
+var filter = map[string]func(*Message) bool{
+	"FilterNotMe":     notMe,
+	"FilterMe":        me,
+	"FilterIncoming":  incoming,
+	"FilterOutgoing":  outgoing,
+	"FilterText":      text,
+	"FilterReply":     reply,
+	"FilterForwarded": forwarded,
+	"FilterCaption":   caption,
+	"FilterEdited":    edited,
+	"FilterAudo":      audio,
+	"FilterDocument":  document,
+	"FilterPhoto":     photo,
+	"FilterSticker":   sticker,
+	"FilterAnimation": animation,
+	"FilterGame":      game,
+	"FilterVideo":     video,
+	"FilterVoice":     voice,
+	"FilterVideoNote": videoNote,
+	"FilterContact":   contact,
+	"FilterLocation":  location,
+	"FilterVenue":     venue,
+	"FilterPoll":      poll,
+	"FilterChannel":   channel,
+	"FilterMedia":     media,
+}
+
+// Filters
+const (
+	FilterNotMe      = "FilterNotMe"      // messages that aren't generated by you yourself.
+	FilterMe         = "FilterMe"         // messages generated by you yourself.
+	FilterIncoming   = "FilterIncoming"   // incoming messages. Messages sent to your own chat (Saved Messages) are also recognised as incoming.
+	FilterOutgoing   = "FilterOutgoing"   // outgoing messages. Messages sent to your own chat (Saved Messages) are not recognized as outgoing.
+	FilterText       = "FilterText"       // Filter text messages.
+	FilterReply      = "FilterReply"      // messages that are replies to other messages.
+	FilterForwarded  = "FilterForwarded"  // messages that are forwarded.
+	FilterCaption    = "FilterCaption"    // media messages that contain captions.
+	FilterEdited     = "FilterEdited"     // Filter edited messages.
+	FilterAudo       = "FilterAudo"       // messages that contain Audio objects.
+	FilterDocument   = "FilterDocument"   // messages that contain Document objects.
+	FilterPhoto      = "FilterPhoto"      // messages that contain Photo objects.
+	FilterSticker    = "FilterSticker"    // messages that contain Sticker objects.
+	FilterAnimation  = "FilterAnimation"  // messages that contain Animation objects.
+	FilterGame       = "FilterGame"       // messages that contain Game objects.
+	FilterVideo      = "FilterVideo"      // messages that contain Video objects.
+	FilterMediaGroup = "FilterMediaGroup" // messages containing photos or videos being part of an album.
+	FilterVoice      = "FilterVoice"      // messages that contain Voice note objects.
+	FilterVideoNote  = "FilterVideoNote"  // messages that contain VideoNote objects.
+	FilterContact    = "FilterContact"    // messages that contain Contact objects.
+	FilterLocation   = "FilterLocation"   // messages that contain Location objects.
+	FilterVenue      = "FilterVenue"      // messages that contain Venue objects.
+	FilterWebPage    = "FilterWebPage"    // messages sent with a webpage preview.
+	FilterPool       = "FilterPool"       // messages that contain Poll objects.
+	FilterPrivate    = "FilterPrivate"    // messages sent in private chats.
+	FilterGroup      = "FilterGroup"      // messages sent in group or supergroup chats.
+	FilterChannel    = "FilterChannel"    // messages sent in channels.
+	FilterMedia      = "FilterMedia"      // media messages.
+)


### PR DESCRIPTION
this is a basic proposal for an event collector which can handle multiple updates based on certain filters. it enables control over what kind of updates are allowed to be passed in a callback function.

```go
// Handle Ctrl+C , Gracefully exit and shutdown
ch := make(chan os.Signal, 2)
signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
go func() {
    <-ch
    collector.Close()
    tdlibClient.Close()
    os.Exit(0)
}()

collector := client.NewEventCollector(tdlibClient)

in := func(cl *client.Client, message client.Message) {
    log.Println("A forwarded message which contains a video was received")
}

edit := func(cl *client.Client, message client.Message) {
    log.Println("This message was edited by somone")
}

cmd := func(cl *client.Client, args []string) {
    log.Println(args)
}

go collector.OnMessage(in, client.FilterVideo, client.FilterForwarded)
go collector.OnEditedMessage(edit, client.FilterNotMe)
go collector.OnCommand(cmd, "test", "/")

collector.Wait()
```