### PR TITLE
FIX: JsonInt64.MarshalJSON missing quotes

### DIFF
--- a/client/tdlib.go
+++ b/client/tdlib.go
@@ -138,8 +138,8 @@ func buildResponseError(data json.RawMessage) error {
 type JsonInt64 int64
 
 // MarshalJSON marshals to json
-func (jsonInt64 *JsonInt64) MarshalJSON() ([]byte, error) {
-	return []byte(strconv.FormatInt(int64(*jsonInt64), 10)), nil
+func (jsonInt64 JsonInt64) MarshalJSON() ([]byte, error) {
+	return []byte(`"`+strconv.FormatInt(int64(jsonInt64), 10)+`"`), nil
 }
 
 // UnmarshalJSON unmarshals from json


### PR DESCRIPTION
Assume you have a struct with `JsonInt64` field in it. And you want to marshal it into JSON and then later Unmarshal it back — you will have an error on Unmarshalling step

See this sample to reproduce:
```
package main

import (
	"encoding/json"
	"fmt"
	"github.com/zelenin/go-tdlib/client"
)

func main() {
	var tmp struct {
		X client.JsonInt64 `json:"x"`
	}
	tmp.X = 123

	b, _ := json.Marshal(tmp)
	fmt.Println("Marshal 1:", string(b)) //Marshal 1: {"x":123}
	json.Unmarshal(b, &tmp)
	fmt.Println("Unmarshal 1:", tmp)     //Unmarshal 1: {2}

	b, _ = json.Marshal(tmp)
	fmt.Println("Marshal 2:", string(b)) //Marshal 2: {"x":2}
	json.Unmarshal(b, &tmp)              //panic: runtime error: slice bounds out of range [1:0]
	fmt.Println("Unmarshal 2:", tmp)
}
```

The problem is very simple: `JsonInt64` methods `MarshalJSON` and `UnmarshalJSON` use different formats:

`JsonInt64.UnmarshalJSON` assumes that value is passed with quotes. So it cuts first and last symbols before converting the value

`JsonInt64.MarshalJSON` has two problems:
1. It is not even called, cause it is declared as a pointer method — so you have to change its declaration first
2. And then it's called, it produces JSON without qoutes around the value. So next time you Unmarshal your JSON long values will be cut, and one-digit values will cause runtime panic

**FIX: change method declaration & add quotes**

P.S. Why do I worry about Marshalling/Unmarshalling back and forth? I receive `Chat` info from API `GetChat`. I want to marshal that info and store it to mongoDB for later use. And I have that error while Unmarshalling back