### PR TITLE
Make clientAuthorizer exported

### DIFF
--- a/client/authorization.go
+++ b/client/authorization.go
@@ -35,7 +35,7 @@ func Authorize(client *Client, authorizationStateHandler AuthorizationStateHandl
 	}
 }
 
-type clientAuthorizer struct {
+type ClientAuthorizerType struct {
 	TdlibParameters chan *TdlibParameters
 	PhoneNumber     chan string
 	Code            chan string
@@ -43,8 +43,8 @@ type clientAuthorizer struct {
 	Password        chan string
 }
 
-func ClientAuthorizer() *clientAuthorizer {
-	return &clientAuthorizer{
+func ClientAuthorizer() *ClientAuthorizerType {
+	return &ClientAuthorizerType{
 		TdlibParameters: make(chan *TdlibParameters, 1),
 		PhoneNumber:     make(chan string, 1),
 		Code:            make(chan string, 1),
@@ -53,7 +53,7 @@ func ClientAuthorizer() *clientAuthorizer {
 	}
 }
 
-func (stateHandler *clientAuthorizer) Handle(client *Client, state AuthorizationState) error {
+func (stateHandler *ClientAuthorizerType) Handle(client *Client, state AuthorizationState) error {
 	stateHandler.State <- state
 
 	switch state.AuthorizationStateType() {
@@ -109,7 +109,7 @@ func (stateHandler *clientAuthorizer) Handle(client *Client, state Authorization
 	return ErrNotSupportedAuthorizationState
 }
 
-func (stateHandler *clientAuthorizer) Close() {
+func (stateHandler *ClientAuthorizerType) Close() {
 	close(stateHandler.TdlibParameters)
 	close(stateHandler.PhoneNumber)
 	close(stateHandler.Code)
@@ -117,7 +117,7 @@ func (stateHandler *clientAuthorizer) Close() {
 	close(stateHandler.Password)
 }
 
-func CliInteractor(clientAuthorizer *clientAuthorizer) {
+func CliInteractor(clientAuthorizer *ClientAuthorizerType) {
 	for {
 		select {
 		case state, ok := <-clientAuthorizer.State:


### PR DESCRIPTION
An unexported type makes authorizer instances impossible to be passed to an external function or put in a struct (for example, for implementing a custom interactor). So I made it exported.